### PR TITLE
fix(induction_and_recursion): typo

### DIFF
--- a/induction_and_recursion.rst
+++ b/induction_and_recursion.rst
@@ -922,7 +922,7 @@ The following example can be found in [GoMM06]_. We declare an inductive type th
     open image_of
 
     def inverse {f : α → β} : Π b, image_of f b → α
-    | .(f a) (imf .(f) a) := a
+    | .(f a) (imf a) := a
 
 In the example above, the inaccessible annotation makes it clear that ``f`` is *not* a pattern matching variable.
 


### PR DESCRIPTION
fix(induction_and_recursion): typo

Change example of inaccessible terms to work with lean 3.11.0 and later. In 3.11.0, previous syntax is wrong due to new rules about implicit-ness of constructors. Fixes identified by Bryan Gin-ge Chen and Reid Barton in https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Inaccessible.20terms.20and.20non-working.20TPIL.20example/near/199825461.